### PR TITLE
Adding a custom message to the init.pp and motd.erb template.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,6 +19,8 @@ class motd {
     default => '0',
   }
 
+  $custommessage = 'This is a production system! All activity monitored.'
+
   file { '/etc/motd':
     ensure  => file,
     content => template("${module_name}/motd.erb"),

--- a/templates/motd.erb
+++ b/templates/motd.erb
@@ -1,4 +1,6 @@
 -------------------------------------------------
+<%= @custommessage %>
+-------------------------------------------------
 Welcome to the host named <%= hostname %>
 <%= operatingsystem %> <%= operatingsystemrelease %> <% if has_variable?("architecture") then %><%= architecture %><% end %>
 -------------------------------------------------


### PR DESCRIPTION
Your puppet module for motd worked fine and had the most detailed information about the system displayed. All I have done is to add a custom message to personalize it for my company's needs. In my case I have motd::custommessage overriden from hiera differently on production, development and staging servers. 
